### PR TITLE
Multi-agent call types: JoinCall (62), JoinCallAnswer (63), candidate agent routing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,16 @@ name: PR CIs
 
 on:
   push:
-    branches: ["*"]
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Retrieve Git Tokens
         env:
           USER: ${{ secrets.GIT_USER }}
@@ -18,19 +20,17 @@ jobs:
           git config --global url."https://${USER}:${TOKEN}@github.com/pedidopago".insteadOf "git+ssh://git@github.com/pedidopago" --replace-all
           git config --global url."https://${USER}:${TOKEN}@github.com/pedidopago".insteadOf "https://github.com/pedidopago" --add
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: ">=1.23.0"
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+          go-version: 1.26.4
       - name: Run Tests
-        env:
-          DATABASE_URL: ""
         run: |
           go test ./...
-      - name: Run static analysis
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2
+      - name: Run vulnerability check
         run: |
-          go vet ./...
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-          staticcheck -go 1.26 ./...
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           go test ./...
       - name: Run linters
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.12.2
       - name: Run vulnerability check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+run:
+  timeout: 5m
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - modernize
+    - errcheck
+    - ineffassign
+    - unused

--- a/fbgraph/calling.go
+++ b/fbgraph/calling.go
@@ -211,7 +211,7 @@ func (c *Client) GetWhatsappSettings(ctx context.Context, whatsappID string) (*W
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -271,12 +271,12 @@ func (c *Client) UpdateWhatsappSettings(ctx context.Context, whatsappID string, 
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return c.errorFromResponse(resp)
 	}
 
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return nil
 }
@@ -313,7 +313,7 @@ func (c *Client) GetMessagingLimitingTier(ctx context.Context, whatsappID string
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", c.errorFromResponse(resp)
 	}
@@ -380,7 +380,7 @@ func (c *Client) GetAppSubscribedWebhooks(ctx context.Context, appID, appSecret 
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
@@ -455,12 +455,12 @@ func (c *Client) PreAcceptCall(ctx context.Context, whatsappID string, r *Accept
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return c.errorFromResponse(resp)
 	}
 
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return nil
 }
@@ -507,12 +507,12 @@ func (c *Client) AcceptCall(ctx context.Context, whatsappID string, r *AcceptCal
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return c.errorFromResponse(resp)
 	}
 
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return nil
 }
@@ -559,12 +559,12 @@ func (c *Client) TerminateCall(ctx context.Context, whatsappID string, callID st
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return c.errorFromResponse(resp)
 	}
 
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return nil
 }
@@ -625,7 +625,7 @@ func (c *Client) InitiateCall(ctx context.Context, phoneNumberID string, r Initi
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -700,7 +700,7 @@ func (c *Client) GetCallPermissions(ctx context.Context, phoneNumberID, userWAID
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}

--- a/fbgraph/client.go
+++ b/fbgraph/client.go
@@ -84,7 +84,7 @@ func (c *Client) SendMessage(phoneID string, msg *MessageObject) (*MessageObject
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -127,7 +127,7 @@ func (c *Client) SendMarketingMessage(phoneID string, msg *MessageObject) (*Mess
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -178,8 +178,8 @@ func (c *Client) UploadMedia(phoneID string, mimeType string, r io.Reader, fsize
 	allok := false
 	defer func() {
 		if !allok {
-			mw.Close()
-			pw.Close()
+			_ = mw.Close()
+			_ = pw.Close()
 		}
 	}()
 
@@ -206,7 +206,7 @@ func (c *Client) UploadMedia(phoneID string, mimeType string, r io.Reader, fsize
 	if err := <-done; err != nil {
 		return "", fmt.Errorf("request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", c.errorFromResponse(resp)
 	}
@@ -236,7 +236,7 @@ func (c *Client) GetMedia(mediaID string) (*GetMediaResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -259,7 +259,7 @@ func (c *Client) DownloadMedia(mr *GetMediaResult, out io.Writer) (nwritten int6
 		return 0, fmt.Errorf("request failed: %w", err)
 	}
 	log.Debug().Interface("media", mr).Int("http_status_code", resp.StatusCode).Interface("response_headers", resp.Header).Msg("downloading media")
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		nwritten, err := io.Copy(out, resp.Body)
 		if err != nil {
@@ -340,7 +340,7 @@ func (c *Client) NewUploadSession(fbAppID string, params NewUploadSessionParams)
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 
@@ -383,7 +383,7 @@ func (c *Client) UploadHeaderHandle(uploadSessionID string, r io.Reader) (h stri
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 
@@ -417,7 +417,7 @@ func (c *Client) errorFromResponse(resp *http.Response) error {
 		Error GraphError `json:"error"`
 	}{}
 	jbdbuff := new(bytes.Buffer)
-	io.Copy(jbdbuff, resp.Body)
+	_, _ = io.Copy(jbdbuff, resp.Body)
 
 	c.lastErrorRawBody = jbdbuff.String()
 

--- a/fbgraph/es.go
+++ b/fbgraph/es.go
@@ -34,7 +34,7 @@ func (c *Client) PostSubscribedApps(ctx context.Context, wabaID string) error {
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 		if ge, ok := AsGraphError(gerr); ok {
@@ -45,6 +45,6 @@ func (c *Client) PostSubscribedApps(ctx context.Context, wabaID string) error {
 		return gerr
 	}
 
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }

--- a/fbgraph/messages.go
+++ b/fbgraph/messages.go
@@ -71,7 +71,7 @@ type ContactObject struct {
 	Birthday  string           `json:"birthday,omitempty"`
 	Emails    []ContactEmail   `json:"emails,omitempty"`
 	Name      ContactName      `json:"name"`
-	Org       ContactOrg       `json:"org,omitempty"`
+	Org       ContactOrg       `json:"org"`
 	Phones    []ContactPhone   `json:"phones,omitempty"`
 	URLs      []ContactURL     `json:"urls,omitempty"`
 }
@@ -193,7 +193,7 @@ type GraphError struct {
 	IsTransient    bool      `json:"is_transient"`     // present in v17+
 	ErrorUserTitle string    `json:"error_user_title"` // present in v17+
 	ErrorUserMsg   string    `json:"error_user_msg"`   // present in v17+
-	ErrorData      ErrorData `json:"error_data,omitempty"`
+	ErrorData      ErrorData `json:"error_data"`
 	FBTraceID      string    `json:"fbtrace_id"`
 	HTTPStatusCode int       `json:"http_status_code"` // this is not originally in the response
 }

--- a/fbgraph/smb_app_data.go
+++ b/fbgraph/smb_app_data.go
@@ -52,7 +52,7 @@ func (c *Client) PostSMBAppData(ctx context.Context, whatsappID string, syncType
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)

--- a/fbgraph/templates.go
+++ b/fbgraph/templates.go
@@ -180,7 +180,7 @@ func (c *Client) GetMessageTemplate(ctx context.Context, id string) (*MessageTem
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -224,7 +224,7 @@ func (c *Client) GetMessageTemplates(ctx context.Context, params GetMessageTempl
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, c.errorFromResponse(resp)
 	}
@@ -261,7 +261,7 @@ func (c *Client) CreateMessageTemplate(ctx context.Context, wabaID string, templ
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 
@@ -317,7 +317,7 @@ func (c *Client) UpdateMessageTemplateCategory(ctx context.Context, templateID s
 		return fmt.Errorf("request failed: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
@@ -373,7 +373,7 @@ func (c *Client) UpdateMessageTemplate(ctx context.Context, templateID string, c
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 
@@ -420,7 +420,7 @@ func (c *Client) DeleteMessageTemplate(ctx context.Context, whatsappBusinessAcco
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		gerr := c.errorFromResponse(resp)
 

--- a/fbgraph/token.go
+++ b/fbgraph/token.go
@@ -53,7 +53,7 @@ func (c *Client) DebugToken(ctx context.Context, inputToken string) (TokenInfo, 
 	if err != nil {
 		return emptyd, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return emptyd, c.errorFromResponse(resp)
 	}
@@ -80,7 +80,7 @@ func (c *Client) NewPermanentAccessToken(ctx context.Context, appID, appSecret, 
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", c.errorFromResponse(resp)
 	}

--- a/msgdriver/host_note.go
+++ b/msgdriver/host_note.go
@@ -1,16 +1,16 @@
 package msgdriver
 
 type HostNote struct {
-	ContactID     uint64                 `json:"contact_id"`
-	WabaContactID string                 `json:"waba_contact_id"`
-	PhoneID       uint                   `json:"phone_id"`
-	Format        string                 `json:"format"`
-	Title         string                 `json:"title"`
-	TitleIcon     string                 `json:"title_icon,omitempty"`
-	Description   string                 `json:"description,omitempty"`
-	AgentID       string                 `json:"agent_id,omitempty"`
-	AgentName     string                 `json:"agent_name,omitempty"`
-	Origin        string                 `json:"origin,omitempty"`
-	Type          string                 `json:"type,omitempty"`
-	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	ContactID     uint64         `json:"contact_id"`
+	WabaContactID string         `json:"waba_contact_id"`
+	PhoneID       uint           `json:"phone_id"`
+	Format        string         `json:"format"`
+	Title         string         `json:"title"`
+	TitleIcon     string         `json:"title_icon,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	AgentID       string         `json:"agent_id,omitempty"`
+	AgentName     string         `json:"agent_name,omitempty"`
+	Origin        string         `json:"origin,omitempty"`
+	Type          string         `json:"type,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
 }

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -188,7 +188,7 @@ func (c *Client) GetMessageByID(ctx context.Context, id string) (rest.AnyMessage
 	outputbuf := new(bytes.Buffer)
 	ofn := &getMessageByIDBogusOutput{
 		fn: func(src io.Reader) {
-			io.Copy(outputbuf, src)
+			_, _ = io.Copy(outputbuf, src)
 		},
 	}
 
@@ -455,7 +455,7 @@ func (c *Client) doRequest(ctx context.Context, method, suffix string, input, ou
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return c.errorFromResponse(ctx, resp)
 	}
@@ -466,7 +466,7 @@ func (c *Client) doRequest(ctx context.Context, method, suffix string, input, ou
 			return nil
 		}
 
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {

--- a/rest/types.go
+++ b/rest/types.go
@@ -432,7 +432,7 @@ type Contact struct {
 	// The whatsapp id (phone number) of the contact.
 	WABAContactID string `json:"waba_contact_id"`
 	// The business-scoped user ID (BSUID) assigned by Meta.
-	UserID mariadb.NullString `json:"user_id,omitempty"`
+	UserID mariadb.NullString `json:"user_id"`
 	// The profile name of the contact.
 	WABAProfileName mariadb.NullString `json:"waba_profile_name"`
 	// The timestamp of the last time the contact was 'seen' online.
@@ -450,7 +450,7 @@ type Contact struct {
 	// The mariadb enum if the message was sent from the contact to the host or viceversa (host|client)
 	LastMessagePreviewOrigin     mariadb.NullString `json:"last_message_preview_origin"`
 	LastMessagePreviewStatus     string             `json:"last_message_preview_status"`
-	LastMessagePreviewWhatsAppID mariadb.NullString `json:"last_message_preview_whatsapp_id,omitempty"`
+	LastMessagePreviewWhatsAppID mariadb.NullString `json:"last_message_preview_whatsapp_id"`
 	// Contact Metadata
 	Metadata map[string]any `json:"metadata"`
 	// The customer_id of ms_customer
@@ -476,7 +476,7 @@ type ContactV2 struct {
 	HostPhoneNumber string    `json:"host_phone_number"`
 	Tags            []string  `json:"tags"`
 	AgentTags       []string  `json:"agent_tags"`
-	LastMessage     time.Time `json:"last_message_timestamp,omitempty"`
+	LastMessage     time.Time `json:"last_message_timestamp"`
 	UnreadMessages  int       `json:"unread_messages"`
 }
 
@@ -843,10 +843,10 @@ type RegisterDriverMessageRequest struct {
 	Buttons                    []Button       `json:"buttons,omitempty"`
 	Header                     *Header        `json:"header,omitempty"`
 	Footer                     string         `json:"footer,omitempty"`
-	CreatedAt                  time.Time      `json:"created_at,omitempty" description:"Message creation date"`
-	SentAt                     time.Time      `json:"sent_at,omitempty" description:"Message sent date"`
-	DeliveredAt                time.Time      `json:"delivered_at,omitempty" description:"Message delivered date"`
-	ReadAt                     time.Time      `json:"read_at,omitempty" description:"Message read date"`
+	CreatedAt                  time.Time      `json:"created_at" description:"Message creation date"`
+	SentAt                     time.Time      `json:"sent_at" description:"Message sent date"`
+	DeliveredAt                time.Time      `json:"delivered_at" description:"Message delivered date"`
+	ReadAt                     time.Time      `json:"read_at" description:"Message read date"`
 	ReplyContact               *ReplyContact  `json:"reply_contact,omitempty"`
 	ReplyMessageID             string         `json:"reply_message_id,omitempty"`
 	ReplyButtonID              string         `json:"reply_button_id,omitempty"`

--- a/shared-types/contact_metadata_test.go
+++ b/shared-types/contact_metadata_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func TestContactMetadata_UnmarshalOnlyKnownFields(t *testing.T) {
 	input := `{
 		"inquiry_id": "inq-123",
@@ -148,7 +146,7 @@ func TestContactMetadata_UnmarshalEmpty(t *testing.T) {
 
 func TestContactMetadata_MarshalOnlyKnownFields(t *testing.T) {
 	cm := ContactMetadata{
-		InquiryID:       ptr("inq-1"),
+		InquiryID:       new("inq-1"),
 		InquiryStatus:   InquiryStatusPending,
 		ChatbotDisabled: MetadataBoolTrue,
 	}
@@ -205,8 +203,8 @@ func TestContactMetadata_MarshalOnlyOtherFields(t *testing.T) {
 
 func TestContactMetadata_MarshalMixed(t *testing.T) {
 	cm := ContactMetadata{
-		InquiryID: ptr("inq-1"),
-		AccountID: ptr("acc-2"),
+		InquiryID: new("inq-1"),
+		AccountID: new("acc-2"),
 		OtherFields: map[string]any{
 			"custom_tag": "vip",
 		},
@@ -235,7 +233,7 @@ func TestContactMetadata_MarshalMixed(t *testing.T) {
 
 func TestContactMetadata_MarshalStructFieldWinsOverOtherFields(t *testing.T) {
 	cm := ContactMetadata{
-		InquiryID: ptr("correct"),
+		InquiryID: new("correct"),
 		OtherFields: map[string]any{
 			"inquiry_id": "wrong",
 		},

--- a/shared-types/contact_metadata_zajson_test.go
+++ b/shared-types/contact_metadata_zajson_test.go
@@ -40,28 +40,6 @@ func zunmarshal[T interface {
 	return v
 }
 
-// zRoundTrip marshals v via Z, unmarshals into a new instance via Z, then
-// JSON-marshals both and compares. It returns the Z-unmarshaled copy.
-func zRoundTrip[T interface {
-	*E
-	ZMarshalJSON(w *zajson.Writer) error
-	ZUnmarshalJSON(r *zajson.Reader) error
-}, E any](t *testing.T, v *E) *E {
-	t.Helper()
-	data := zmarshal(t, T(v))
-	got := zunmarshal[T](t, data)
-	return got
-}
-
-func assertJSONEqual(t *testing.T, label string, a, b any) {
-	t.Helper()
-	ja, _ := json.Marshal(a)
-	jb, _ := json.Marshal(b)
-	if string(ja) != string(jb) {
-		t.Errorf("%s: got %s, want %s", label, ja, jb)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // ContactMetadata Z round-trip tests
 // ---------------------------------------------------------------------------
@@ -168,7 +146,7 @@ func TestZ_ContactMetadata_UnmarshalEmpty(t *testing.T) {
 
 func TestZ_ContactMetadata_MarshalKnownFields(t *testing.T) {
 	cm := ContactMetadata{
-		InquiryID:       ptr("inq-1"),
+		InquiryID:       new("inq-1"),
 		InquiryStatus:   InquiryStatusPending,
 		ChatbotDisabled: MetadataBoolTrue,
 	}
@@ -922,9 +900,9 @@ func TestZ_ContactMetadata_MarketingDisabledReason(t *testing.T) {
 
 func TestZ_MetadataBool_Formats(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		json     string
-		want     MetadataBool
+		name string
+		json string
+		want MetadataBool
 	}{
 		{"bool true", `{"chatbot_disabled": true}`, MetadataBoolTrue},
 		{"bool false", `{"chatbot_disabled": false}`, MetadataBoolFalse},

--- a/whapi/graph_objects.go
+++ b/whapi/graph_objects.go
@@ -54,13 +54,13 @@ type EntryObject struct {
 type ChangeObjectField string
 
 const (
-	ChangeObjectFieldMessages         ChangeObjectField = "messages"
-	ChangeObjectFieldContacts         ChangeObjectField = "contacts"
-	ChangeObjectFieldErrors           ChangeObjectField = "errors"
-	ChangeObjectFieldStatuses         ChangeObjectField = "statuses"
-	ChangeObjectFieldHistory          ChangeObjectField = "history"
-	ChangeObjectFieldSMBMessageEchoes ChangeObjectField = "smb_message_echoes"
-	ChangeObjectFieldSMBAppStateSync  ChangeObjectField = "smb_app_state_sync"
+	ChangeObjectFieldMessages                     ChangeObjectField = "messages"
+	ChangeObjectFieldContacts                     ChangeObjectField = "contacts"
+	ChangeObjectFieldErrors                       ChangeObjectField = "errors"
+	ChangeObjectFieldStatuses                     ChangeObjectField = "statuses"
+	ChangeObjectFieldHistory                      ChangeObjectField = "history"
+	ChangeObjectFieldSMBMessageEchoes             ChangeObjectField = "smb_message_echoes"
+	ChangeObjectFieldSMBAppStateSync              ChangeObjectField = "smb_app_state_sync"
 	ChangeObjectFieldCalls                        ChangeObjectField = "calls"
 	ChangeObjectFieldMessageTemplateQualityUpdate ChangeObjectField = "message_template_quality_update"
 )
@@ -96,7 +96,7 @@ type ValueObject struct {
 	// Calls https://developers.facebook.com/docs/whatsapp/cloud-api/calling/user-initiated-calls
 	Calls []CallObject `json:"calls,omitempty"`
 	// Metadata for the business that is subscribed to the webhook.
-	Metadata ValueObjectMetadata `json:"metadata,omitempty"`
+	Metadata ValueObjectMetadata `json:"metadata"`
 
 	// template specific fields:
 
@@ -112,17 +112,17 @@ type ValueObject struct {
 	// only included if template disabled
 	DisableInfo struct {
 		DisableDate string `json:"disable_date,omitempty"`
-	} `json:"disable_info,omitempty"`
+	} `json:"disable_info"`
 	// only included if template locked or unlocked
 	OtherInfo struct {
 		Title       string `json:"title,omitempty"`
 		Description string `json:"description,omitempty"`
-	} `json:"other_info,omitempty"`
+	} `json:"other_info"`
 	// only included if template rejected with INVALID_FORMAT reason
 	RejectionInfo struct {
 		Reason         string `json:"reason,omitempty"`
 		Recommendation string `json:"recommendation,omitempty"`
-	} `json:"rejection_info,omitempty"`
+	} `json:"rejection_info"`
 }
 
 // GetContactProfileName returns the contact profile name for the given waid or userID.
@@ -646,7 +646,7 @@ type HistoryThreadObject struct {
 		UserID       string `json:"user_id,omitempty"`        // BSUID
 		ParentUserID string `json:"parent_user_id,omitempty"` // Only included if parent BSUIDs enabled before sync request
 		Username     string `json:"username,omitempty"`       // Only included if user has enabled usernames feature before sync request
-	} `json:"context,omitempty"`
+	} `json:"context"`
 	Messages []MessageEHObject `json:"messages"`
 }
 
@@ -672,7 +672,7 @@ type MessageEHObject struct {
 	Context          *fbgraph.MessageContext `json:"context,omitempty"`
 	HistoryContext   struct {
 		Status string `json:"status"` // MESSAGE_STATUS - DELIVERED ERROR PENDING PLAYED READ SENT
-	} `json:"history_context,omitempty"`
+	} `json:"history_context"`
 }
 
 func (m MessageEHObject) GetType() string {
@@ -907,7 +907,7 @@ type ErrorObject struct {
 	Message   string    `json:"message,omitempty"`
 	ErrorData struct {
 		Details string `json:"details,omitempty"`
-	} `json:"error_data,omitempty"`
+	} `json:"error_data"`
 }
 
 type ErrorCode int

--- a/wsapi/calls.go
+++ b/wsapi/calls.go
@@ -141,6 +141,7 @@ type SendBrowserCandidate struct {
 	PhoneID   uint            `json:"phone_id"`
 	CallID    string          `json:"call_id"`
 	Candidate json.RawMessage `json:"candidate"`
+	AgentID   string          `json:"agent_id,omitempty"` // set for multi-agent calls to route to the correct agent's peer connection
 }
 
 // CallStarted is broadcast by the server when a call has been successfully established.
@@ -352,6 +353,22 @@ type CallInviteRejected struct {
 // LeaveCall is sent by an agent to leave a multi-agent call without terminating it.
 type LeaveCall struct {
 	CallID string `json:"call_id"`
+}
+
+// JoinCall is sent by a secondary agent to join an active multi-agent call.
+// AgentID and AgentName are filled by the server from JWT.
+type JoinCall struct {
+	CallID    string `json:"call_id"`
+	PhoneID   uint   `json:"phone_id"`
+	OfferSDP  string `json:"offer_sdp"`
+	AgentID   string `json:"agent_id"`   // server fills from JWT
+	AgentName string `json:"agent_name"` // server fills from JWT
+}
+
+// JoinCallAnswer is sent by the server back to the joining agent with the SDP answer.
+type JoinCallAnswer struct {
+	CallID    string `json:"call_id"`
+	AnswerSDP string `json:"answer_sdp"`
 }
 
 // CallAgentJoined is broadcast to all agents in a call when a new agent's WebRTC is live.

--- a/wsapi/calls.go
+++ b/wsapi/calls.go
@@ -366,9 +366,12 @@ type JoinCall struct {
 }
 
 // JoinCallAnswer is sent by the server back to the joining agent with the SDP answer.
+// On failure AnswerSDP is empty and Reason is set to one of:
+// CALL_NOT_FOUND, CALL_FULL, ALREADY_IN_CALL, JOIN_FAILED.
 type JoinCallAnswer struct {
 	CallID    string `json:"call_id"`
 	AnswerSDP string `json:"answer_sdp"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // CallAgentJoined is broadcast to all agents in a call when a new agent's WebRTC is live.

--- a/wsapi/calls.go
+++ b/wsapi/calls.go
@@ -367,7 +367,7 @@ type JoinCall struct {
 
 // JoinCallAnswer is sent by the server back to the joining agent with the SDP answer.
 // On failure AnswerSDP is empty and Reason is set to one of:
-// CALL_NOT_FOUND, CALL_FULL, ALREADY_IN_CALL, JOIN_FAILED.
+// CALL_NOT_FOUND, CALL_FULL, ALREADY_IN_CALL, NOT_READY, JOIN_FAILED.
 type JoinCallAnswer struct {
 	CallID    string `json:"call_id"`
 	AnswerSDP string `json:"answer_sdp"`

--- a/wsapi/hostmessage.go
+++ b/wsapi/hostmessage.go
@@ -17,7 +17,7 @@ type HostMessage struct {
 	PhoneID         uint   `json:"phone_id"`
 	HostPhoneNumber string `json:"host_phone_number"`
 	// The id (phone number) of the recipient (client).
-	WABARecipientID         string                            `json:"waba_recipient_id"`
+	WABARecipientID string `json:"waba_recipient_id"`
 	// The business-scoped user ID (BSUID) of the recipient.
 	UserID                  string                            `json:"user_id,omitempty"`
 	WABATimestamp           time.Time                         `json:"waba_timestamp"`
@@ -39,7 +39,7 @@ type HostMessage struct {
 	FailedReason            *SentMessageFailedReason          `json:"failed_reason,omitempty"`
 	Preview                 string                            `json:"preview,omitempty"`
 	Origin                  string                            `json:"origin,omitempty"`
-	CreatedAt               time.Time                         `json:"created_at,omitempty"`
+	CreatedAt               time.Time                         `json:"created_at"`
 	CreatedAtNano           int64                             `json:"created_at_nano,omitempty"`
 	Context                 *MessageContext                   `json:"context,omitempty"`
 	Reactions               []MessageReaction                 `json:"reactions,omitempty"`

--- a/wsapi/message.go
+++ b/wsapi/message.go
@@ -69,6 +69,8 @@ const (
 	MessageTypeCallAgentLeft      MessageType = 59 // server → all agents in call
 	MessageTypeUnreadCountChanged MessageType = 60 // server sends this to the clients
 	MessageTypeCallInviteFailed   MessageType = 61 // server → inviter
+	MessageTypeJoinCall           MessageType = 62 // CLIENT -> SERVER
+	MessageTypeJoinCallAnswer     MessageType = 63 // SERVER -> CLIENT
 
 	MessageTypeMockClientMessages MessageType = 230
 	MessageTypeGenericError       MessageType = 235
@@ -133,6 +135,8 @@ type Message struct {
 	CallAgentJoined            *CallAgentJoined            `json:"call_agent_joined,omitempty"`
 	CallAgentLeft              *CallAgentLeft              `json:"call_agent_left,omitempty"`
 	CallInviteFailed           *CallInviteFailed           `json:"call_invite_failed,omitempty"`
+	JoinCall                   *JoinCall                   `json:"join_call,omitempty"`
+	JoinCallAnswer             *JoinCallAnswer             `json:"join_call_answer,omitempty"`
 	UnreadCountChanged         *UnreadCountChanged         `json:"unread_count_changed,omitempty"`
 }
 

--- a/wsapi/message.go
+++ b/wsapi/message.go
@@ -357,8 +357,8 @@ type HostNoteButton struct {
 	SelectedBy struct {
 		AgentID   string `json:"agent_id,omitempty"`
 		AgentName string `json:"agent_name,omitempty"`
-	} `json:"selected_by,omitempty"`
-	SelectedAt time.Time `json:"selected_at,omitempty"`
+	} `json:"selected_by"`
+	SelectedAt time.Time `json:"selected_at"`
 }
 
 // HostNoteUpdated is broadcast to connected clients when a host note is modified
@@ -403,7 +403,7 @@ type ReactionEventData struct {
 	Emoji         string    `json:"emoji"`
 	AgentID       string    `json:"agent_id,omitempty"`
 	AgentName     string    `json:"agent_name,omitempty"`
-	CreatedAt     time.Time `json:"created_at,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
 }
 
 // MessageContext contains information about the original message that a reply or forward refers to.
@@ -419,7 +419,7 @@ type MessageReaction struct {
 	ID            string    `json:"id,omitempty"`
 	WABAContactID string    `json:"waba_contact_id"`
 	Emoji         string    `json:"emoji"`
-	CreatedAt     time.Time `json:"created_at,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
 	AgentID       string    `json:"agent_id,omitempty"`
 	AgentName     string    `json:"agent_name,omitempty"`
 	Status        string    `json:"status,omitempty"`

--- a/wsapi/metadata.go
+++ b/wsapi/metadata.go
@@ -156,14 +156,14 @@ type ContactMetadataToSend struct {
 	ContactPhoneNumber           string           `json:"contact_phone_number,omitempty"`
 	IsNewContact                 bool             `json:"is_new_contact,omitempty"`
 	Metadata                     json.RawMessage  `json:"metadata,omitempty"`
-	LastActivity                 mariadb.NullTime `json:"last_activity,omitempty"`
+	LastActivity                 mariadb.NullTime `json:"last_activity"`
 	LastMessagePreview           string           `json:"last_message_preview,omitempty"`
 	LastMessagePreviewOrigin     string           `json:"last_message_preview_origin,omitempty"`
 	LastMessagePreviewStatus     string           `json:"last_message_preview_status,omitempty"`
-	LastMessageTimestamp         mariadb.NullTime `json:"last_message_timestamp,omitempty"`
-	LastMessageReceivedTimestamp mariadb.NullTime `json:"last_message_received_timestamp,omitempty"`
+	LastMessageTimestamp         mariadb.NullTime `json:"last_message_timestamp"`
+	LastMessageReceivedTimestamp mariadb.NullTime `json:"last_message_received_timestamp"`
 	UnreadMessages               *int             `json:"unread_messages,omitempty"`
-	ERPLastSync                  mariadb.NullTime `json:"erp_last_sync,omitempty"`
+	ERPLastSync                  mariadb.NullTime `json:"erp_last_sync"`
 	ColorTags                    []ColorTag       `json:"color_tags,omitempty"`
 	Last24HWindow                string           `json:"last_24h_window,omitempty"`
 	Last24HWindowUnix            int64            `json:"last_24h_window_unix,omitempty"`


### PR DESCRIPTION
## Summary

WS API additions for multi-agent calls (PPS-8164):

- `MessageTypeJoinCall` (62, client→server) and `MessageTypeJoinCallAnswer` (63, server→client) — secondary-agent join handshake, separated from the original SDP types due to different synchronicity semantics.
- `SendBrowserCandidate.AgentID` — identifies which agent's peer a candidate belongs to. Client→server it is optional (the server stamps it from JWT); server→client the frontend must discard candidates whose `agent_id` is not its own, since all peers share the call_id.
- `JoinCallAnswer.Reason` — failure vocabulary: `CALL_NOT_FOUND`, `CALL_FULL`, `ALREADY_IN_CALL`, `NOT_READY`, `JOIN_FAILED` (empty `answer_sdp` on failure).

## Merge order (cross-repo)

**Merge this first**, then tag `v1.10.1`. ms-wabaman's `feature/multi-agent-call` PR must be re-pinned from its pseudo-version to the tag before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)